### PR TITLE
Update package validation baseline to 2.0.3

### DIFF
--- a/src/Pure.RelationalSchema/Pure.RelationalSchema.csproj
+++ b/src/Pure.RelationalSchema/Pure.RelationalSchema.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>2.0.2</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>2.0.3</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `2.0.2` to `2.0.3` following the successful publish.